### PR TITLE
SDK-388 Send missing events to Firebase

### DIFF
--- a/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin+FAPluginBuilderLifeCycleDelegate.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin+FAPluginBuilderLifeCycleDelegate.swift
@@ -12,6 +12,10 @@ extension PerformancesMonitoringPlugin: FAPluginBuilderLifeCycleDelegate {
     public func builderWillStart() {
         saveCurrentDate(forEvent: SDKEvent.sdk_start)
     }
+    
+    public func builderDidStart() {
+        saveCurrentDate(forEvent: SDKEvent.stop_sdk_start)
+    }
         
     public func builderRemoveSplashView() {
         saveCurrentDate(forEvent: SDKEvent.sdk_remove_splashview)

--- a/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin.swift
@@ -17,6 +17,7 @@ public protocol PerformancesMonitoringDelegate: NSObject {
 
 public enum SDKEvent: String {
     case sdk_start
+    case stop_sdk_start
     case sdk_remove_splashview
     case sdk_all_webviews_are_loaded
 }

--- a/Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/FirebasePerformanceTracesManager.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/FirebasePerformanceTracesManager.swift
@@ -16,7 +16,7 @@ public protocol FirebasePerformanceDelegate {
     func performanceTraceNameForWebViewDidFinish(webViewAtIndex: Int) -> String
     func performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: Int) -> String
     func performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: Int) -> String
-    func performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: Int) -> String
+    func performanceTraceNameForWebDocumentReadyStateInteractive(webViewAtIndex: Int) -> String
     func performanceTraceNameForWebLoad(webViewAtIndex: Int) -> String
 }
 
@@ -149,9 +149,9 @@ extension FirebasePerformanceTracesManager: TracesManager {
             let webLoadTrace = Performance.startTrace(name: webLoadTraceName)
             startedTraces[webLoadTraceName] = webLoadTrace
             
-            let webDocumentReadyStateIntractiveTraceName = delegate?.performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index)
-            let webDocumentReadyStateIntractiveTrace = Performance.startTrace(name: webDocumentReadyStateIntractiveTraceName)
-            startedTraces[webDocumentReadyStateIntractiveTraceName] = webDocumentReadyStateIntractiveTrace
+            let webDocumentReadyStateInteractiveTraceName = delegate?.performanceTraceNameForWebDocumentReadyStateInteractive(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateInteractive(webViewAtIndex: index)
+            let webDocumentReadyStateInteractiveTrace = Performance.startTrace(name: webDocumentReadyStateInteractiveTraceName)
+            startedTraces[webDocumentReadyStateInteractiveTraceName] = webDocumentReadyStateInteractiveTrace
             
             let webDocumentReadyStateCompleteTraceName = delegate?.performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: index)
             let webDocumentReadyStateCompleteTrace = Performance.startTrace(name: webDocumentReadyStateCompleteTraceName)
@@ -188,7 +188,7 @@ extension FirebasePerformanceTracesManager: TracesManager {
         }
         
         if webViewEvent == .web_DocumentReadyStateIntractive{
-            let traceName = delegate?.performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index)
+            let traceName = delegate?.performanceTraceNameForWebDocumentReadyStateInteractive(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateInteractive(webViewAtIndex: index)
             if let trace = startedTraces[traceName] {
                 sectionViewController.setAttributes(toTrace: trace, delegate: self.delegate)
                 trace.stop()
@@ -238,7 +238,7 @@ extension FirebasePerformanceTracesManager: FirebasePerformanceDelegate {
         return "webView_\(webViewAtIndex)_DocumentReadyStateComplete"
     }
     
-    public func performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: Int) -> String {
+    public func performanceTraceNameForWebDocumentReadyStateInteractive(webViewAtIndex: Int) -> String {
         return "webView_\(webViewAtIndex)_DocumentReadyStateIntractive"
     }
     

--- a/Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/FirebasePerformanceTracesManager.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/FirebasePerformanceTracesManager.swift
@@ -15,6 +15,9 @@ public protocol FirebasePerformanceDelegate {
     func performanceTraceNameForSDKEvent(for event: SDKEvent) -> String
     func performanceTraceNameForWebViewDidFinish(webViewAtIndex: Int) -> String
     func performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: Int) -> String
+    func performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: Int) -> String
+    func performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: Int) -> String
+    func performanceTraceNameForWebLoad(webViewAtIndex: Int) -> String
 }
 
 public class FirebasePerformanceTracesManager: NSObject {
@@ -94,6 +97,10 @@ extension FirebasePerformanceTracesManager {
 extension FirebasePerformanceTracesManager: TracesManager {
     public func performancesMonitoring(sdkEvent: SDKEvent) {
         if sdkEvent == .sdk_start {
+            let sdkStart = delegate?.performanceTraceNameForSDKEvent(for: .sdk_start) ?? performanceTraceNameForSDKEvent(for: .sdk_start)
+            let sdkStartTrace = Performance.startTrace(name: sdkStart)
+            startedTraces[sdkStart] = sdkStartTrace
+            
             let sdkRemoveSplashviewTraceName =
                 delegate?.performanceTraceNameForSDKEvent(for: .sdk_remove_splashview) ?? performanceTraceNameForSDKEvent(for: .sdk_remove_splashview)
             let sdkRemoveSplashviewTrace = Performance.startTrace(name: sdkRemoveSplashviewTraceName)
@@ -116,6 +123,12 @@ extension FirebasePerformanceTracesManager: TracesManager {
             trace.stop()
             startedTraces[SDKEvent.sdk_all_webviews_are_loaded.rawValue] = nil
         }
+        
+        if sdkEvent == .stop_sdk_start, let trace = startedTraces[SDKEvent.sdk_start.rawValue] {
+            setAttributes(toTrace: trace, delegate: self.delegate)
+            trace.stop()
+            startedTraces[SDKEvent.sdk_start.rawValue] = nil
+        }
     }
     
     public func performancesMonitoring(webViewEvent: LoadingEvent, sectionViewController: FASectionViewController) {
@@ -131,6 +144,18 @@ extension FirebasePerformanceTracesManager: TracesManager {
                 delegate?.performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: index) ?? performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: index)
             let DOMContentLoadedTrace = Performance.startTrace(name: DOMContentLoadedTraceName)
             startedTraces[DOMContentLoadedTraceName] = DOMContentLoadedTrace
+            
+            let webLoadTraceName = delegate?.performanceTraceNameForWebLoad(webViewAtIndex: index) ?? performanceTraceNameForWebLoad(webViewAtIndex: index)
+            let webLoadTrace = Performance.startTrace(name: webLoadTraceName)
+            startedTraces[webLoadTraceName] = webLoadTrace
+            
+            let webDocumentReadyStateIntractiveTraceName = delegate?.performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index)
+            let webDocumentReadyStateIntractiveTrace = Performance.startTrace(name: webDocumentReadyStateIntractiveTraceName)
+            startedTraces[webDocumentReadyStateIntractiveTraceName] = webDocumentReadyStateIntractiveTrace
+            
+            let webDocumentReadyStateCompleteTraceName = delegate?.performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: index)
+            let webDocumentReadyStateCompleteTrace = Performance.startTrace(name: webDocumentReadyStateCompleteTraceName)
+            startedTraces[webDocumentReadyStateCompleteTraceName] = webDocumentReadyStateCompleteTrace
         }
         
         if webViewEvent == .native_didFinish {
@@ -146,6 +171,33 @@ extension FirebasePerformanceTracesManager: TracesManager {
         if webViewEvent == .web_DOMContentLoaded {
             let traceName =
                 delegate?.performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: index) ?? performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: index)
+            if let trace = startedTraces[traceName] {
+                sectionViewController.setAttributes(toTrace: trace, delegate: self.delegate)
+                trace.stop()
+                startedTraces[traceName] = nil
+            }
+        }
+        
+        if webViewEvent == .web_load {
+            let traceName = delegate?.performanceTraceNameForWebLoad(webViewAtIndex: index) ?? performanceTraceNameForWebLoad(webViewAtIndex: index)
+            if let trace = startedTraces[traceName] {
+                sectionViewController.setAttributes(toTrace: trace, delegate: self.delegate)
+                trace.stop()
+                startedTraces[traceName] = nil
+            }
+        }
+        
+        if webViewEvent == .web_DocumentReadyStateIntractive{
+            let traceName = delegate?.performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: index)
+            if let trace = startedTraces[traceName] {
+                sectionViewController.setAttributes(toTrace: trace, delegate: self.delegate)
+                trace.stop()
+                startedTraces[traceName] = nil
+            }
+        }
+        
+        if webViewEvent == .web_DocumentReadyStateComplete {
+            let traceName = delegate?.performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: index) ?? performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: index)
             if let trace = startedTraces[traceName] {
                 sectionViewController.setAttributes(toTrace: trace, delegate: self.delegate)
                 trace.stop()
@@ -180,5 +232,17 @@ extension FirebasePerformanceTracesManager: FirebasePerformanceDelegate {
 
     public func performanceTraceNameForWebViewDOMContentLoaded(webViewAtIndex: Int) -> String {
         return "webView_\(webViewAtIndex)_DOMContentLoaded"
+    }
+    
+    public func performanceTraceNameForWebDocumentReadyStateComplete(webViewAtIndex: Int) -> String {
+        return "webView_\(webViewAtIndex)_DocumentReadyStateComplete"
+    }
+    
+    public func performanceTraceNameForWebDocumentReadyStateIntractive(webViewAtIndex: Int) -> String {
+        return "webView_\(webViewAtIndex)_DocumentReadyStateIntractive"
+    }
+    
+    public func performanceTraceNameForWebLoad(webViewAtIndex: Int) -> String {
+        return "webView_\(webViewAtIndex)_load"
     }
 }

--- a/Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/GROWPerformanceTracesManager.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/GROWPerformanceTracesManager.swift
@@ -88,7 +88,6 @@ extension GROWTracesManager: TracesManager {
         }
         
         let address = "\(Unmanaged.passUnretained(webView).toOpaque())"
-        let strEvent = webViewEvent.rawValue
         
         var trace: PluginMonitorTrace?
         switch(webViewEvent){


### PR DESCRIPTION
Ticket: https://bryj.atlassian.net/browse/SDK-388

Task:
Following Events were missing in the Monitoring Plugin: 

BuildSDK

- **native_start** (I haven't implemented this yet because it's not an event. It is introduced as a variable, originally used to track the webview event when it begins loading a URL)
- sdk_start

WebView.

- web_load
- web_DocumentReadyStateIntractive
- web_DocumentReadyStateComplete


POF:

<img width="1177" alt="Screenshot 2024-10-08 at 11 26 55 AM" src="https://github.com/user-attachments/assets/1a01ac2a-44af-454c-b1ff-4d79b24c89b5">
<img width="1011" alt="Screenshot 2024-10-08 at 11 27 45 AM" src="https://github.com/user-attachments/assets/66168048-b5e9-48ec-b146-401fb0797d48">
<img width="1005" alt="Screenshot 2024-10-08 at 11 28 02 AM" src="https://github.com/user-attachments/assets/9ec3e7af-b751-4123-898d-fb35b4d1763d">
