### PR TITLE
SDK-395: Hide/Show tabbar logic fix

### DIFF
--- a/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin+FAPluginSectionViewControllerLifeCycleDelegate.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin+FAPluginSectionViewControllerLifeCycleDelegate.swift
@@ -10,7 +10,8 @@ import Foundation
 import WebKit
 
 extension PerformancesMonitoringPlugin: FAPluginSectionViewControllerLifeCycleDelegate {
-    public func lifeCycleWebViewWillBeInitialized(sectionViewController: FASectionViewController, configuration: WKWebViewConfiguration) {}
+
+    public func lifeCycleWebViewWillBeInitialized(sectionViewController: FASectionViewController, configuration: WKWebViewConfiguration) { }
     
     public func lifeCycleWebViewInitialized(sectionViewController: FASectionViewController) {
         let handlers: [String] = [
@@ -19,13 +20,20 @@ extension PerformancesMonitoringPlugin: FAPluginSectionViewControllerLifeCycleDe
             PerformancesPluginScriptMessageHandler.performance_DocumentReadyStateIntractive,
             PerformancesPluginScriptMessageHandler.performance_load,
         ]
-        for handler in handlers {
-            sectionViewController.userContentController()?.removeScriptMessageHandler(forName: handler)
-            sectionViewController.userContentController()?.add(scriptMessageHandler, name: handler)
+        
+        handlers.forEach { handler in
+            self.registerScriptMessageHandler(sectionViewController.userContentController(), name: handler)
         }
+
         let classBundle = Bundle(for: PerformancesMonitoringPlugin.self)
-        if let bundle = Bundle(path: classBundle.bundlePath.appending("/Build-V3-Plugin-Monitoring-ios.bundle")) {
-            sectionViewController.webView()!.addJavascriptFileInjectionIfNeeded(resource: "interface_performances", forMainFrameOnly: true, bundle: bundle)
+        if let bundle = Bundle(path: classBundle.bundlePath.appending("/Build-V3-Plugin-Monitoring-ios.bundle")),
+            let webView = sectionViewController.webView() {
+            webView.addJavascriptFileInjectionIfNeeded(resource: "interface_performances", forMainFrameOnly: true, bundle: bundle)
         }
+    }
+
+    private func registerScriptMessageHandler(_ controller: WKUserContentController?, name: String) {
+        controller?.removeScriptMessageHandler(forName: name)
+        controller?.add(self.scriptMessageHandler, name: name)
     }
 }

--- a/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin+FAPluginSectionViewControllerLifeCycleDelegate.swift
+++ b/Build-V3-Plugin-Monitoring-ios/Classes/Core/PerformancesMonitoringPlugin+FAPluginSectionViewControllerLifeCycleDelegate.swift
@@ -13,15 +13,16 @@ extension PerformancesMonitoringPlugin: FAPluginSectionViewControllerLifeCycleDe
     public func lifeCycleWebViewWillBeInitialized(sectionViewController: FASectionViewController, configuration: WKWebViewConfiguration) {}
     
     public func lifeCycleWebViewInitialized(sectionViewController: FASectionViewController) {
-        sectionViewController.userContentController()?.add(scriptMessageHandler,
-                                                           name:PerformancesPluginScriptMessageHandler.performance_DOMContentLoaded)
-        sectionViewController.userContentController()?.add(scriptMessageHandler,
-                                                           name:PerformancesPluginScriptMessageHandler.performance_DocumentReadyStateComplete)
-        sectionViewController.userContentController()?.add(scriptMessageHandler,
-                                                           name:PerformancesPluginScriptMessageHandler.performance_DocumentReadyStateIntractive)
-        sectionViewController.userContentController()?.add(scriptMessageHandler,
-                                                           name:PerformancesPluginScriptMessageHandler.performance_load)
-        
+        let handlers: [String] = [
+            PerformancesPluginScriptMessageHandler.performance_DOMContentLoaded,
+            PerformancesPluginScriptMessageHandler.performance_DocumentReadyStateComplete,
+            PerformancesPluginScriptMessageHandler.performance_DocumentReadyStateIntractive,
+            PerformancesPluginScriptMessageHandler.performance_load,
+        ]
+        for handler in handlers {
+            sectionViewController.userContentController()?.removeScriptMessageHandler(forName: handler)
+            sectionViewController.userContentController()?.add(scriptMessageHandler, name: handler)
+        }
         let classBundle = Bundle(for: PerformancesMonitoringPlugin.self)
         if let bundle = Bundle(path: classBundle.bundlePath.appending("/Build-V3-Plugin-Monitoring-ios.bundle")) {
             sectionViewController.webView()!.addJavascriptFileInjectionIfNeeded(resource: "interface_performances", forMainFrameOnly: true, bundle: bundle)


### PR DESCRIPTION
Ticket:
https://bryj.atlassian.net/browse/SDK-395

Description:
The delegate was adding without confirming if already exists, which was causing a crash on the SDK 3.9.7 beta.