### PR TITLE
[SDK-600] - Support ARM64 architecture

### DIFF
--- a/Build-V3-Plugin-Monitoring-ios.podspec
+++ b/Build-V3-Plugin-Monitoring-ios.podspec
@@ -35,6 +35,4 @@ Pod::Spec.new do |s|
     sp.dependency 'Build-V3-Plugin-Monitoring-ios/Core'
     sp.dependency 'FirebasePerformance', '10.25.0'
   end
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'}
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/Build-V3-Plugin-Monitoring-ios.podspec
+++ b/Build-V3-Plugin-Monitoring-ios.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Build-V3-Plugin-Monitoring-ios'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'Build-V3-Plugin-Monitoring-ios is a plugin capable of monitoring the app performance.'
   s.description      = <<-DESC
   Build-V3-Plugin-Monitoring-ios is a plugin capable of monitoring the app performance.

--- a/Build-V3-Plugin-Monitoring-ios.podspec
+++ b/Build-V3-Plugin-Monitoring-ios.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '16.0'
   s.swift_version = '5.0'
   s.default_subspec = 'Core'
-  s.dependency 'FASDKBuild-ios', '>= 3.9.10'
+  s.dependency 'FASDKBuild-ios', '~> 3.9.10'
   s.subspec 'Core' do |sp|
     sp.source_files = 'Build-V3-Plugin-Monitoring-ios/Classes/Core/**/*'
     sp.resource_bundles = {'Build-V3-Plugin-Monitoring-ios' => ['Build-V3-Plugin-Monitoring-ios/Assets/*.{js}', 'PrivacyInfo.xcprivacy']}
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.subspec 'GROW' do |sp|
     sp.source_files = ['Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/GROWPerformanceTracesManager.swift']
     sp.dependency 'Build-V3-Plugin-Monitoring-ios/Core'
-    sp.dependency 'GROW'
+    sp.dependency 'GROW', '~> 1.2.5'
   end
   s.subspec 'FirebasePerformance' do |sp|
     sp.source_files = ['Build-V3-Plugin-Monitoring-ios/Classes/TracesManagers/FirebasePerformanceTracesManager.swift']

--- a/Example/Build-V3-Plugin-Monitoring-ios.xcodeproj/project.pbxproj
+++ b/Example/Build-V3-Plugin-Monitoring-ios.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 3ZK98N757X;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Build-V3-Plugin-Monitoring-ios/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -385,6 +386,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 3ZK98N757X;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Build-V3-Plugin-Monitoring-ios/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -7,11 +7,11 @@ target 'Build-V3-Plugin-Monitoring-ios-Example' do
   pod 'Build-V3-Plugin-Monitoring-ios/FirebasePerformance', :path => '../'
   pod 'Build-V3-Plugin-Monitoring-ios/GROW', :path => '../'
   pod 'FASDKBuild-ios', '3.9.10', :source => 'git@github.com:bryjai/bryj-build-private-pods.git'
+  pod 'GROW', '1.2.5', :source => 'git@github.com:bryjai/bryj-build-private-pods.git'
 end
 
 post_install do |installer|
   installer.pods_project.build_configurations.each do |config|
-    config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
     config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
   end
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,0 +1,134 @@
+PODS:
+  - Build-V3-Plugin-Monitoring-ios/Core (1.0.4):
+    - FASDKBuild-ios (~> 3.9.10)
+  - Build-V3-Plugin-Monitoring-ios/FirebasePerformance (1.0.4):
+    - Build-V3-Plugin-Monitoring-ios/Core
+    - FASDKBuild-ios (~> 3.9.10)
+    - FirebasePerformance (= 10.25.0)
+  - FASDKBuild-ios (3.9.10)
+  - FirebaseABTesting (10.29.0):
+    - FirebaseCore (~> 10.0)
+  - FirebaseCore (10.29.0):
+    - FirebaseCoreInternal (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.12)
+    - GoogleUtilities/Logger (~> 7.12)
+  - FirebaseCoreExtension (10.29.0):
+    - FirebaseCore (~> 10.0)
+  - FirebaseCoreInternal (10.29.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseInstallations (10.29.0):
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
+    - PromisesObjC (~> 2.1)
+  - FirebasePerformance (10.25.0):
+    - FirebaseCore (~> 10.5)
+    - FirebaseInstallations (~> 10.0)
+    - FirebaseRemoteConfig (~> 10.0)
+    - FirebaseSessions (~> 10.5)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/Environment (~> 7.13)
+    - GoogleUtilities/ISASwizzler (~> 7.13)
+    - GoogleUtilities/MethodSwizzler (~> 7.13)
+    - GoogleUtilities/UserDefaults (~> 7.13)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseRemoteConfig (10.29.0):
+    - FirebaseABTesting (~> 10.0)
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - FirebaseRemoteConfigInterop (~> 10.23)
+    - FirebaseSharedSwift (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseRemoteConfigInterop (10.29.0)
+  - FirebaseSessions (10.29.0):
+    - FirebaseCore (~> 10.5)
+    - FirebaseCoreExtension (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/Environment (~> 7.13)
+    - GoogleUtilities/UserDefaults (~> 7.13)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+    - PromisesSwift (~> 2.1)
+  - FirebaseSharedSwift (10.29.0)
+  - GoogleDataTransport (9.4.1):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Environment (7.13.3):
+    - GoogleUtilities/Privacy
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/ISASwizzler (7.13.3):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (7.13.3):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/MethodSwizzler (7.13.3):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - "GoogleUtilities/NSData+zlib (7.13.3)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (7.13.3)
+  - GoogleUtilities/UserDefaults (7.13.3):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - nanopb (2.30910.0):
+    - nanopb/decode (= 2.30910.0)
+    - nanopb/encode (= 2.30910.0)
+  - nanopb/decode (2.30910.0)
+  - nanopb/encode (2.30910.0)
+  - PromisesObjC (2.4.0)
+  - PromisesSwift (2.4.0):
+    - PromisesObjC (= 2.4.0)
+
+DEPENDENCIES:
+  - Build-V3-Plugin-Monitoring-ios/Core (from `../`)
+  - Build-V3-Plugin-Monitoring-ios/FirebasePerformance (from `../`)
+  - FASDKBuild-ios (= 3.9.10)
+
+SPEC REPOS:
+  "git@github.com:bryjai/bryj-build-private-pods.git":
+    - FASDKBuild-ios
+  trunk:
+    - FirebaseABTesting
+    - FirebaseCore
+    - FirebaseCoreExtension
+    - FirebaseCoreInternal
+    - FirebaseInstallations
+    - FirebasePerformance
+    - FirebaseRemoteConfig
+    - FirebaseRemoteConfigInterop
+    - FirebaseSessions
+    - FirebaseSharedSwift
+    - GoogleDataTransport
+    - GoogleUtilities
+    - nanopb
+    - PromisesObjC
+    - PromisesSwift
+
+EXTERNAL SOURCES:
+  Build-V3-Plugin-Monitoring-ios:
+    :path: "../"
+
+SPEC CHECKSUMS:
+  Build-V3-Plugin-Monitoring-ios: 4930157fed867ca71c6ef49eb4fcbcd4fcaded69
+  FASDKBuild-ios: ba17cd6c9468fd429f18695a5b69a240a1b48222
+  FirebaseABTesting: d87f56707159bae64e269757a6e963d490f2eebe
+  FirebaseCore: 30e9c1cbe3d38f5f5e75f48bfcea87d7c358ec16
+  FirebaseCoreExtension: 705ca5b14bf71d2564a0ddc677df1fc86ffa600f
+  FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
+  FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
+  FirebasePerformance: bae7778c4448b37f2a75cb72d30c2df7d10ff227
+  FirebaseRemoteConfig: 48ef3f243742a8d72422ccfc9f986e19d7de53fd
+  FirebaseRemoteConfigInterop: 6efda51fb5e2f15b16585197e26eaa09574e8a4d
+  FirebaseSessions: dbd14adac65ce996228652c1fc3a3f576bdf3ecc
+  FirebaseSharedSwift: 20530f495084b8d840f78a100d8c5ee613375f6e
+  GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
+  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  nanopb: 438bc412db1928dac798aa6fd75726007be04262
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
+
+PODFILE CHECKSUM: c5fff78eeca7628bc0be2e95b893335b62a13c95
+
+COCOAPODS: 1.15.2


### PR DESCRIPTION
https://bryj.atlassian.net/browse/SDK-600

This PR should only be merged once GrowSDK 1.2.5 is officially released in order to be properly tested. GrowSDK by default already supported ARM64 architecture but its CocoaPods definition needs to be updated. To be done on 1.2.5


<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-17 at 23 22 49" src="https://github.com/user-attachments/assets/d1468820-909f-46b7-8d99-4ffac76b12f6" />
